### PR TITLE
Create register.js

### DIFF
--- a/register.js
+++ b/register.js
@@ -1,0 +1,2 @@
+const jsdomDevtoolsFormatter = require('./index.js');
+jsdomDevtoolsFormatter.install();


### PR DESCRIPTION
The idea is to provide a module so people can just do `node --require jsdom-devtools-formatter/register.js test.js` without having to directly modify their code. Test frameworks also commonly have similar command-line flags like Mocha.

This not only eases integration, but it also makes it possible for people to just install and use globally.